### PR TITLE
JS embedding

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -3,7 +3,7 @@ import type { Config } from '@jest/types';
 const config: Config.InitialOptions = {
     preset: 'ts-jest',
     testEnvironment: 'node',
-    verbose: true,
+    verbose: false,
     testTimeout: 30000,
     testMatch: ['**/test/**/*.test.ts'],
 };

--- a/package.json
+++ b/package.json
@@ -50,7 +50,10 @@
             {
                 "language": "adblock",
                 "scopeName": "text.adblock",
-                "path": "./syntaxes/out/adblock.plist"
+                "path": "./syntaxes/out/adblock.plist",
+                "embeddedLanguages": {
+                    "source.js": "javascript"
+                }
             }
         ]
     },

--- a/syntaxes/adblock.yaml-tmlanguage
+++ b/syntaxes/adblock.yaml-tmlanguage
@@ -5,7 +5,7 @@
 #
 # GitHub Linguist can use this file directly, but during the build, we convert it to a .plist file,
 # so the VSCode extension can use it. Development is done in this .yaml-tmlanguage file.
-# 
+#
 # If you aren't familiar with TextMate Language Grammars, you can read the following documentations:
 # - https://macromates.com/manual/en/language_grammars
 # - https://www.sublimetext.com/docs/3/syntax.html
@@ -239,7 +239,27 @@ repository:
           "6":
             name: punctuation.section.adblock
   jsRules:
+    # In this case, we embed the JS grammar in the adblock grammar
+    # by using the include: "source.js" scope.
+    # This is an external grammar, so it should be installed separately,
+    # but both VSCode and GitHub Linguist will recognize it.
+    # See https://github.com/github-linguist/linguist/discussions/6020#discussioncomment-3397226
     patterns:
+      # Do not confuse with #%#//scriptlet, so we use a negative lookahead
+      # to make sure the separator is not followed by //scriptlet
+      - begin: "^(.*?)(#@?%#(?!\\/\\/scriptlet))"
+        beginCaptures:
+          "1":
+            patterns:
+              - include: "#domainListCommaSeparated"
+          "2":
+            name: keyword.control.adblock
+        end: "$"
+        contentName: source.js
+        patterns:
+          - include: source.js
+      # Mark any other JS inject as invalid, typically unclosed / invalid
+      # scriptlet calls
       - match: "^(.*?)(#@?%#)(.+)$"
         captures:
           "1":
@@ -248,8 +268,7 @@ repository:
           "2":
             name: keyword.control.adblock
           "3":
-            patterns:
-              - include: "#jsFunction"
+            name: invalid.illegal
   basicRulesNoUrl:
     patterns:
       - match: "^(\\$)(.+)$"
@@ -517,10 +536,6 @@ repository:
             name: keyword.operator.adblock
       - name: invalid.illegal.adblock
         match: ".*"
-  jsFunction:
-    patterns:
-      - name: constant.character.jscode.adblock
-        match: ".+"
   cssStyle:
     patterns:
       - match: "(@media[\\s]+[^\\{]*)(\\{)([\\s]*[^\\{]*)(\\{)([\\s]*[^\\}]*)(\\})[\\s]*(\\})"

--- a/test/grammar/cosmetic/js-inject.test.ts
+++ b/test/grammar/cosmetic/js-inject.test.ts
@@ -1,0 +1,39 @@
+/**
+ * @file Tests for JS injection rules
+ */
+
+import { AdblockTokenizer, getAdblockTokenizer } from '../common/get-adblock-tokenizer';
+import { expectTokens } from '../common/token-expectation';
+
+let tokenize: AdblockTokenizer;
+
+// Before running any tests, we should load the grammar and get the tokenizer
+beforeAll(async () => {
+    tokenize = await getAdblockTokenizer();
+});
+
+describe('JS injection rules', () => {
+    test('should tokenize valid JS injections', () => {
+        expectTokens(
+            tokenize,
+            '#%#window.hello = 1',
+            [
+                { fragment: '#%#', scopes: ['text.adblock', 'keyword.control.adblock'] },
+                { fragment: 'window.hello = 1', scopes: ['text.adblock', 'source.js'] },
+            ],
+        );
+    });
+
+    test('should detect invalid cases', () => {
+        // Unclosed scriptlet call. Since it's not closed, it's not matches as a scriptlet call,
+        // but #%# is "stronger" than scriptlet injection, and we shouldn't tokenize it as a JS comment
+        expectTokens(
+            tokenize,
+            '#%#//scriptlet(\'a\',',
+            [
+                { fragment: '#%#', scopes: ['text.adblock', 'keyword.control.adblock'] },
+                { fragment: '//scriptlet(\'a\',', scopes: ['text.adblock', 'invalid.illegal'] },
+            ],
+        );
+    });
+});


### PR DESCRIPTION
This PR embeds the JS grammar into the adblock grammar, in a similar analogy to how JS or CSS is embedded in HTML. The picture below shows the result:

![image](https://user-images.githubusercontent.com/57285466/235110920-144b8e10-7a63-47fe-aed7-b6ebd870a7f6.png)

Since JS is an "external grammar", so it should be installed separately, but both VSCode and GitHub Linguist will recognize it. See https://github.com/github-linguist/linguist/discussions/6020#discussioncomment-3397226