### PR TITLE
Fix ignore files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
+*.log
 *.vsix
 .DS_Store
+coverage
 node_modules
 out

--- a/.vscodeignore
+++ b/.vscodeignore
@@ -6,7 +6,9 @@
 **/yarn.lock
 .eslintignore
 .eslintrc.yaml
+.github/**
 .gitignore
+.husky/**
 .vscode-test/**
 .vscode/**
 .yarnrc


### PR DESCRIPTION
This PR will improve the following:

- `.gitignore` should ignore Jest coverage reports / logs
- `.vscodeignore` should ignore GitHub workflows and the `.husky` folder