### PR TITLE
Detect external AGLint installations, support for extension settings

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -19,7 +19,7 @@
                 "!**/node_modules/**"
             ],
             "autoAttachChildProcesses": true,
-            "preLaunchTask": "npm: build"
+            "preLaunchTask": "npm: dev"
         }
     ]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -3,7 +3,7 @@
     "tasks": [
         {
             "type": "npm",
-            "script": "esbuild",
+            "script": "dev",
             "group": "build",
             "presentation": {
                 "panel": "dedicated",

--- a/README.md
+++ b/README.md
@@ -28,7 +28,8 @@ Table of Contents:
 - [Introduction](#introduction)
   - [Features](#features)
     - [Syntax highlighting](#syntax-highlighting)
-    - [Adblock rule linter](#adblock-rule-linter)
+    - [AGLint integration (linter)](#aglint-integration-linter)
+    - [Configuration](#configuration)
     - [GitHub Linguist support](#github-linguist-support)
   - [Ideas \& Questions](#ideas--questions)
   - [Reporting Issues](#reporting-issues)
@@ -73,13 +74,26 @@ syntaxes. Nowadays it is unimaginable to work with code without highlighting,
 which helps you to distinguish different parts of the code and makes it easier
 to read.
 
-### Adblock rule linter
+### AGLint integration (linter)
 
 We integrated [AGLint][aglint] into this
 extension, that makes it able to check your rules for various issues, such as
 invalid syntax, invalid domains, invalid / incompatible CSS selectors,
 unknown / incompatible scriptlets, bad practices, etc. For more information
 about AGLint, please refer to its [repository][aglint].
+
+AGLint integration is done in the following way:
+1. Extension will search local AGLint installation (if it is installed) and use
+   it for linting. First, it will search for local installation in the current
+   workspace, and if it is not found, it will search for a global installation.
+   This is an ideal behavior, because if you have a local installation, it
+   guarantees that you will use the same version of AGLint, and the results will
+   be the same.
+2. If the extension doesn't find any installation, it will use the bundled
+   version of AGLint, which is included in the extension itself. Usually, it is
+   the latest version of AGLint. The advantage of this approach is that you
+   don't need to install AGLint manually, and you can start using the extension
+   immediately after installation.
 
 > :warning: Please note that the linter is under active development, so it may
 > not work properly for some rules. If you find any issues, please report them
@@ -88,6 +102,16 @@ about AGLint, please refer to its [repository][aglint].
 
 [aglint]: https://github.com/AdguardTeam/AGLint
 [aglintissues]: https://github.com/AdguardTeam/AGLint/issues
+
+### Configuration
+
+This extension provides the following configuration options:
+
+| Option | Description | Default value | Possible values |
+| ------ | ----------- | ------------- | --------------- |
+| `adblock.enableAglint` | Enable or disable AGLint integration. If disabled, only syntax highlighting and other language features will be available. | `true` | `true`, `false` |
+| `adblock.useExternalAglintPackages` | If enabled, extension will search for AGLint installations in the system. If disabled, extension will use its own AGLint installation, which is included in the extension (integrated AGLint bundle). If you have AGLint installed in your system / project, it is recommended to enable this option in order to provide consistent results. | `true` | `true`, `false` |
+| `adblock.packageManager` | Package manager to use for searching global AGLint installations. Set it to your preferred package manager. | `npm` | `npm`, `yarn`, `pnpm` |
 
 ### GitHub Linguist support
 

--- a/package.json
+++ b/package.json
@@ -50,7 +50,10 @@
             {
                 "language": "adblock",
                 "scopeName": "text.adblock",
-                "path": "./syntaxes/out/adblock.plist"
+                "path": "./syntaxes/out/adblock.plist",
+                "embeddedLanguages": {
+                    "source.js": "javascript"
+                }
             }
         ],
         "configuration": {

--- a/package.json
+++ b/package.json
@@ -50,39 +50,54 @@
             {
                 "language": "adblock",
                 "scopeName": "text.adblock",
-                "path": "./syntaxes/out/adblock.plist",
-                "embeddedLanguages": {
-                    "source.js": "javascript"
+                "path": "./syntaxes/out/adblock.plist"
+            }
+        ],
+        "configuration": {
+            "type": "object",
+            "title": "Adblock",
+            "properties": {
+                "adblock.enableAglint": {
+                    "scope": "resource",
+                    "type": "boolean",
+                    "default": true,
+                    "description": "Enable or disable AGLint integration. If disabled, only syntax highlighting and other language features will be available."
+                },
+                "adblock.useExternalAglintPackages": {
+                    "scope": "resource",
+                    "type": "boolean",
+                    "default": true,
+                    "description": "If enabled, extension will search for AGLint installations in the system. If disabled, extension will use its own AGLint installation, which is included in the extension (integrated AGLint bundle). If you have AGLint installed in your system / project, it is recommended to enable this option in order to provide consistent results."
+                },
+                "adblock.packageManager": {
+                    "scope": "resource",
+                    "type": "string",
+                    "enum": [
+                        "npm",
+                        "yarn",
+                        "pnpm"
+                    ],
+                    "enumDescriptions": [
+                        "Node Package Manager",
+                        "Yarn Package Manager",
+                        "pnpm Package Manager"
+                    ],
+                    "default": "npm",
+                    "description": "Package manager to use for searching global AGLint installations. Set it to your preferred package manager."
                 }
             }
-        ]
+        }
     },
     "scripts": {
-        "client:esbuild-prod": "yarn client:esbuild-base --minify",
-        "client:esbuild-base": "esbuild ./client/src/extension.ts --bundle --outfile=client/out/extension.js --external:vscode --format=cjs --platform=node",
-        "client:esbuild": "yarn client:esbuild-base --sourcemap",
-        "client:esbuild-watch": "yarn client:esbuild-base --sourcemap --watch",
-        "client:test-compile": "tsc -p ./client",
-        "client:lint": "eslint ./client/src --ext .ts",
-        "client:clean": "rimraf client/out",
-        "server:esbuild-prod": "yarn server:esbuild-base --minify",
-        "server:esbuild-base": "esbuild ./server/src/server.ts --bundle --outfile=server/out/server.js --external:vscode --format=cjs --platform=node",
-        "server:esbuild": "yarn server:esbuild-base --sourcemap",
-        "server:esbuild-watch": "yarn server:esbuild-base --sourcemap --watch",
-        "server:test-compile": "tsc -p ./server",
-        "server:lint": "eslint ./server/src --ext .ts",
-        "server:clean": "rimraf server/out",
-        "esbuild-prod": "yarn client:esbuild-prod && yarn server:esbuild-prod",
-        "esbuild": "yarn client:esbuild && yarn server:esbuild",
-        "build": "yarn grammar:build && yarn esbuild",
-        "esbuild-watch": "yarn concurrently \"yarn server:esbuild-watch\" \"yarn client:esbuild-watch\"",
-        "test-compile": "yarn client:test-compile && yarn server:test-compile",
-        "clean": "yarn client:clean && yarn server:clean",
+        "dev": "yarn concurrently -n grammar,client,server,aglint \"ts-node tools/grammar-builder.ts\" \"esbuild ./client/src/extension.ts --bundle --outfile=client/out/extension.js --external:vscode --format=cjs --platform=node --sourcemap\" \"esbuild ./server/src/server.ts --bundle --outfile=server/out/server.js --external:vscode --external:./integrated-aglint --format=cjs --platform=node --sourcemap\" \"esbuild ./server/src/aglint.ts --bundle --outfile=server/out/aglint.js --format=cjs --platform=node --sourcemap\"",
+        "dev-watch": "concurrently -n watch-client,watch-server,watch-aglint \"esbuild ./client/src/extension.ts --bundle --outfile=client/out/extension.js --external:vscode --format=cjs --platform=node --sourcemap --watch\" \"esbuild ./server/src/server.ts --bundle --outfile=server/out/server.js --external:vscode --external:./integrated-aglint --format=cjs --platform=node --sourcemap --watch\" \"esbuild ./server/src/aglint.ts --bundle --outfile=server/out/aglint.js --format=cjs --platform=node --sourcemap --watch\"",
+        "prod": "yarn clean && ts-node tools/grammar-builder.ts && esbuild ./client/src/extension.ts --bundle --outfile=client/out/extension.js --external:vscode --format=cjs --platform=node --minify && yarn esbuild ./server/src/server.ts --bundle --outfile=server/out/server.js --external:vscode --external:\"./integrated-aglint\" --format=cjs --platform=node --minify && yarn esbuild ./server/src/aglint.ts --bundle --outfile=server/out/aglint.js --format=cjs --platform=node --minify",
+        "clean": "rimraf ./client/out && rimraf ./server/out && rimraf ./syntaxes/out",
+        "test-compile": "tsc -p ./client --noEmit && tsc -p ./server --noEmit",
         "lint": "eslint . --ext .ts",
-        "postinstall": "cd client && yarn && cd ../server && yarn && cd ..",
-        "generate-vsix": "yarn grammar:build && yarn esbuild-prod && vsce package --yarn --out vscode-adblock.vsix",
         "test": "jest",
-        "grammar:build": "ts-node tools/grammar-builder.ts",
+        "generate-vsix": "vsce package --yarn --out vscode-adblock.vsix",
+        "postinstall": "cd client && yarn && cd ../server && yarn && cd ..",
         "prepare": "husky install"
     },
     "devDependencies": {

--- a/server/package.json
+++ b/server/package.json
@@ -12,6 +12,10 @@
         "vscode-languageserver-textdocument": "^1.0.8"
     },
     "devDependencies": {
-        "@adguard/aglint": "1.0.11"
+        "@adguard/aglint": "1.0.11",
+        "@types/clone-deep": "^4.0.1",
+        "@types/semver": "^7.3.13",
+        "clone-deep": "^4.0.1",
+        "semver": "^7.5.0"
     }
 }

--- a/server/src/aglint.ts
+++ b/server/src/aglint.ts
@@ -1,0 +1,13 @@
+/**
+ * @file Integrated version of AGLint
+ *
+ * In this file, we simply re-export the AGLint API from the @adguard/aglint
+ * package, which is a dev dependency of this server package, so we simply call
+ * it "integrated" / "bundled" version.
+ *
+ * We always make a separate bundle for this file, so the server bundle can
+ * import it as a fallback if it doesn't found any other AGLint installation
+ * with module finder.
+ */
+
+export * from '@adguard/aglint';

--- a/server/src/common/constants.ts
+++ b/server/src/common/constants.ts
@@ -1,0 +1,16 @@
+/**
+ * @file General constant values used across the server
+ */
+
+/**
+ * Name of the AGLint package, probably will never change
+ */
+export const AGLINT_PACKAGE_NAME = '@adguard/aglint';
+
+/**
+ * URL to the AGLint GitHub repository
+ */
+export const AGLINT_REPO_URL = 'https://github.com/AdguardTeam/AGLint';
+
+export const LF = '\n';
+export const EMPTY = '';

--- a/server/src/settings.ts
+++ b/server/src/settings.ts
@@ -1,0 +1,31 @@
+/**
+ * @file Extension settings
+ *
+ * Guide to add new settings to the extension:
+ *
+ * 1. Add a new entry to:
+ *   - extension metadata (package.json: contributes.configuration.properties)
+ *   - extension settings interface (settings.ts: ExtensionSettings)
+ *   - default settings object (settings.ts: defaultSettings)
+ * 2. Implement the logic in the server.ts file
+ */
+
+import { NPM, PackageManager } from './utils/package-managers';
+
+/**
+ * Represents the extension settings
+ */
+export interface ExtensionSettings {
+    enableAglint: boolean;
+    useExternalAglintPackages: boolean;
+    packageManager: PackageManager;
+}
+
+/**
+ * Default extension settings
+ */
+export const defaultSettings: ExtensionSettings = {
+    enableAglint: true,
+    useExternalAglintPackages: true,
+    packageManager: NPM,
+};

--- a/server/src/utils/aglint-resolver.ts
+++ b/server/src/utils/aglint-resolver.ts
@@ -1,0 +1,89 @@
+/**
+ * @file Utility functions to find AGLint installations
+ */
+
+import { Files } from 'vscode-languageserver/node';
+import {
+    NPM,
+    PNPM,
+    PackageManager,
+    TraceFunction,
+    YARN,
+    findGlobalPathForPackageManager,
+} from './package-managers';
+import { AGLINT_PACKAGE_NAME } from '../common/constants';
+
+/**
+ * Priority of package managers. We will try to find global AGLint installation in
+ * this order (first element has the highest priority).
+ */
+export const PACKAGE_MANAGER_PRIORITY: PackageManager[] = [NPM, YARN, PNPM];
+
+/**
+ * Resolve the path to the AGLint module. First, we try to find it in the current
+ * working directory, then we try to find it in the global path of the package
+ * managers in the given priority order.
+ *
+ * If we didn't find the AGLint module, we return undefined, which means that
+ * the extension will use the integrated version of AGLint.
+ *
+ * @param cwd Current working directory
+ * @param tracer Trace function
+ * @param packageManagers Package managers to search for global AGLint installations.
+ * - The priority of the package managers is defined by the order of the array.
+ * - If you specify an empty array, global path search will be skipped.
+ * - If you specify only one package manager, we will skip the search for
+ * the others. For example, if you specify only NPM in the array, we will
+ * try to find AGLint only in the global NPM path, and we will skip the search
+ * for Yarn and PNPM.
+ * @returns Path to the AGLint module or `undefined` if not found
+ */
+export async function resolveAglintModulePath(
+    cwd: string,
+    tracer: TraceFunction,
+    packageManagers: PackageManager[] = PACKAGE_MANAGER_PRIORITY,
+): Promise<string | undefined> {
+    // First, try to find AGLint in the current working directory
+    try {
+        const aglintPath = await Files.resolve(AGLINT_PACKAGE_NAME, cwd, cwd, tracer);
+
+        // If we found it, return the path and abort the search
+        if (aglintPath) {
+            return aglintPath;
+        }
+    } catch (error: unknown) {
+        // "Files.resolve" throws an error if the package is not found, but we need
+        // to continue our search
+    }
+
+    // If we didn't find local installation, try to find it in the global path.
+    // We will try to find it in the global path of the package managers in the
+    // given order
+    for (const packageManager of packageManagers) {
+        // Find the global path for the actual package manager
+        const globalPath = await findGlobalPathForPackageManager(packageManager, tracer);
+
+        // If we didn't find the global path, continue with the next package manager,
+        // because the current one seems to be not installed
+        if (!globalPath) {
+            continue;
+        }
+
+        // Otherwise, try to find AGLint in the found global path
+        try {
+            const aglintPath = await Files.resolve(AGLINT_PACKAGE_NAME, globalPath, cwd, tracer);
+
+            if (aglintPath) {
+                return aglintPath;
+            }
+        } catch (error: unknown) {
+            // Error tolerance: if the function throws an error, we ignore it,
+            // and continue with the next package manager. In the worst case,
+            // we will return undefined, which means that AGLint is not installed,
+            // but the extension will still work, because we have a fallback
+            // to the integrated version of AGLint.
+        }
+    }
+
+    return undefined;
+}

--- a/server/src/utils/package-managers.ts
+++ b/server/src/utils/package-managers.ts
@@ -1,0 +1,134 @@
+/**
+ * @file Utility functions for package managers
+ */
+
+import { execSync } from 'child_process';
+import { isAbsolute } from 'path';
+import { Files } from 'vscode-languageserver/node';
+import { EMPTY } from '../common/constants';
+
+/**
+ * Node Package Manager
+ *
+ * @see https://www.npmjs.com/
+ */
+export const NPM = 'npm';
+
+/**
+ * Yarn Package Manager
+ *
+ * @see https://yarnpkg.com/
+ */
+export const YARN = 'yarn';
+
+/**
+ * PNPM Package Manager
+ *
+ * @see https://pnpm.io/
+ */
+export const PNPM = 'pnpm';
+
+/**
+ * Type of supported package managers
+ */
+export type PackageManager = typeof NPM | typeof YARN | typeof PNPM;
+
+/**
+ * Type of trace function. It's the same as the trace function
+ * as used in the VSCode server, but we define it here to give
+ * a more convenient way to use it via the type alias.
+ */
+export type TraceFunction = (message: string, verbose?: string) => void;
+
+/**
+ * Finds the global path for PNPM. This isn't implemented in the
+ * VSCode server, so we need to do it here.
+ *
+ * @param tracer Trace function (optional)
+ * @returns Path to the global PNPM root or undefined if not found
+ */
+export function findPnpmRoot(tracer?: TraceFunction): string | undefined {
+    try {
+        // Execute `pnpm root -g` command to find the global root.
+        // If the command fails (e.g. PNPM is not installed or
+        // not in the PATH), the execSync will throw an error
+        const result = execSync('pnpm root -g').toString().trim();
+
+        // If the command succeeded, we should check if the result
+        // is an absolute path. If it's not, we should ignore it
+        if (isAbsolute(result)) {
+            if (tracer) {
+                tracer(`Found global PNPM root: ${result}`);
+            }
+
+            return result;
+        }
+
+        if (tracer) {
+            tracer(`Global PNPM root is not an absolute path: ${result}`);
+        }
+    } catch (error: unknown) {
+        // If the execution failed, we simply ignore the error,
+        // and consider the PNPM root as not found
+        if (tracer) {
+            tracer(`Error while finding global PNPM root: ${error}`);
+        }
+    }
+
+    return undefined;
+}
+
+/**
+ * Find the path to the global root of the given package manager
+ *
+ * @param packageManager Name of the package manager (npm, yarn, pnpm)
+ * @param tracer Trace function (optional)
+ * @returns Path to the root directory of the package manager or undefined if not found
+ * or cannot be resolved
+ */
+export async function findGlobalPathForPackageManager(
+    packageManager: PackageManager,
+    tracer?: TraceFunction,
+): Promise<string | undefined> {
+    try {
+        switch (packageManager) {
+            case NPM:
+                // eslint-disable-next-line max-len
+                // TODO: It seems that this function marked as deprecated in the VSCode server, so we should find a better way to do this.
+                // Anyway, this solution is works for now, so it doesn't seem to be a big problem
+                return Files.resolveGlobalNodePath(tracer);
+            case YARN:
+                return Files.resolveGlobalYarnPath(tracer);
+            case PNPM:
+                return findPnpmRoot(tracer);
+            default:
+                return undefined;
+        }
+    } catch (error: unknown) {
+        // Error tolerance: if the function throws an error, we simply ignore it,
+        // and consider the global path as not found
+        return undefined;
+    }
+}
+
+/**
+ * Returns the installation command for the given package manager and package name
+ *
+ * @param packageManager Name of the package manager (npm, yarn, pnpm)
+ * @param packageName Name of the package to install
+ * @param global Whether to install the package globally or not (default: false)
+ * @returns Corresponding installation command for the given package manager
+ */
+export function getInstallationCommand(packageManager: PackageManager, packageName: string, global = false): string {
+    switch (packageManager) {
+        case NPM:
+            return `npm install ${global ? '-g ' : EMPTY}${packageName}`;
+        case YARN:
+            return `yarn add ${global ? 'global ' : EMPTY}${packageName}`;
+        case PNPM:
+            return `pnpm install ${global ? '-g ' : EMPTY}${packageName}`;
+        default:
+            // Theoretically, this should never happen
+            return 'Cannot determine the package manager';
+    }
+}

--- a/server/yarn.lock
+++ b/server/yarn.lock
@@ -43,6 +43,16 @@
     core-js-pure "^3.25.1"
     regenerator-runtime "^0.13.11"
 
+"@types/clone-deep@^4.0.1":
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/@types/clone-deep/-/clone-deep-4.0.1.tgz#7c488443ab9f571cd343d774551b78e9264ea990"
+  integrity sha512-bdkCSkyVHsgl3Goe1y16T9k6JuQx7SiDREkq728QjKmTZkGJZuS8R3gGcnGzVuGBP0mssKrzM/GlMOQxtip9cg==
+
+"@types/semver@^7.3.13":
+  version "7.3.13"
+  resolved "https://registry.yarnpkg.com/@types/semver/-/semver-7.3.13.tgz#da4bfd73f49bd541d28920ab0e2bf0ee80f71c91"
+  integrity sha512-21cFJr9z3g5dW8B0CVI9g2O9beqaThGQ6ZFBqHfwhzLDKUxaqTIy3vnfah/UPkfOiF2pLq+tGz+W8RyCskuslw==
+
 ansi-escapes@^4.2.1:
   version "4.3.2"
   resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-4.3.2.tgz#6b2291d1db7d98b6521d5f1efa42d0f3a9feb65e"
@@ -278,7 +288,7 @@ regenerator-runtime@^0.13.11:
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz#f6dca3e7ceec20590d07ada785636a90cdca17f9"
   integrity sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==
 
-semver@^7.3.8:
+semver@^7.3.8, semver@^7.5.0:
   version "7.5.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.5.0.tgz#ed8c5dc8efb6c629c88b23d41dc9bf40c1d96cd0"
   integrity sha512-+XC0AD/R7Q2mPSRuy2Id0+CGTZ98+8f+KvwirxOKIEyid+XSx6HbC63p+O4IndTHuX5Z+JxQ0TghCkO5Cg/2HA==


### PR DESCRIPTION
Closes https://github.com/AdguardTeam/VscodeAdblockSyntax/issues/75

Changes:
- When the extension is loaded, it checks whether AGLint is installed locally or globally. If it finds an installed version, it can use it instead of the integrated one. Here's an important TODO, we need to check the AGLint version (below a certain threshold the installed AGLint may be incompatible with the extension - typically if the API ever changes). However, to do this AGLint needs to export its version number, so I would resolve this in a different PR, later (most of the check is already prepared in this PR)
- It is now possible to make settings on the extension, demo:
  ![image](https://user-images.githubusercontent.com/57285466/235641365-6db7809c-6937-409f-b894-101d0339a726.png)
- Simplify and optimize build commands with parallel execution. Watch mode should be improved, see https://github.com/AdguardTeam/VscodeAdblockSyntax/issues/88 (but also in a different PR)
- Some minor fixes, e.g. in filesystem watcher

Tested on Windows / Linux